### PR TITLE
feat(back): #1 AI add errors handler

### DIFF
--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -3,4 +3,5 @@
 class ApplicationController < ActionController::API
   include ActionController::Cookies
   include Authenticatable
+  include ErrorHandling
 end

--- a/backend/app/controllers/auth/registrations_controller.rb
+++ b/backend/app/controllers/auth/registrations_controller.rb
@@ -7,13 +7,10 @@ module Auth
     # POST /auth/register
     def create
       user = User.new(registration_params)
+      user.save!
 
-      if user.save
-        cookie_store.write(user.generate_jwt)
-        render json: UserSerializer.new(user).as_json, status: :created
-      else
-        render json: { errors: user.errors.full_messages }, status: :unprocessable_entity
-      end
+      cookie_store.write(user.generate_jwt)
+      render json: UserSerializer.new(user).as_json, status: :created
     end
 
     private

--- a/backend/app/controllers/auth/sessions_controller.rb
+++ b/backend/app/controllers/auth/sessions_controller.rb
@@ -9,8 +9,7 @@ module Auth
       user = User.find_by(email: login_params[:email]&.downcase&.strip)
 
       unless user&.authenticate(login_params[:password])
-        return render json: { error: "Invalid email or password" },
-                      status: :unauthorized
+        raise Authentication::Errors::InvalidCredentials
       end
 
       cookie_store.write(user.generate_jwt)

--- a/backend/app/controllers/concerns/authenticatable.rb
+++ b/backend/app/controllers/concerns/authenticatable.rb
@@ -5,8 +5,6 @@ module Authenticatable
 
   included do
     before_action :authenticate_user!
-
-    rescue_from Authentication::Errors::Base, with: :render_unauthorized
   end
 
   private
@@ -16,8 +14,6 @@ module Authenticatable
     raise Authentication::Errors::InvalidToken if token.blank?
 
     @current_user = User.from_jwt(token)
-  rescue Authentication::Errors::Base => e
-    render_unauthorized(e)
   end
 
   def current_user
@@ -26,11 +22,5 @@ module Authenticatable
 
   def cookie_store
     @cookie_store ||= Authentication::CookieStore.new(cookies)
-  end
-
-  def render_unauthorized(exception = nil)
-    render json: {
-      error: exception&.message || "Unauthorized"
-    }, status: :unauthorized
   end
 end

--- a/backend/app/controllers/concerns/error_handling.rb
+++ b/backend/app/controllers/concerns/error_handling.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# Centralizes exception handling for all controllers.
+#
+# Rescue order (most to least specific):
+#   1. Errors::Base subclasses (authorization, domain)
+#   2. ActiveRecord::RecordInvalid (AR validation failures)
+#   3. StandardError (catch-all for unmapped exceptions)
+module ErrorHandling
+  extend ActiveSupport::Concern
+
+  included do
+    rescue_from StandardError,              with: :handle_standard_error
+    rescue_from BaseError,                  with: :handle_application_error
+    rescue_from ActiveRecord::RecordInvalid, with: :handle_record_invalid
+  end
+
+  private
+
+  # Renders a single Errors::Base (domain / authorization) as the JSON envelope.
+  # HTTP status is derived from the first 3 characters of the error code.
+  def handle_application_error(exception)
+    status = http_status_from_code(exception.code)
+    render_errors(
+      [ { message: exception.message, code: exception.code } ],
+      status:
+    )
+  end
+
+  # Converts every ActiveRecord validation error into one envelope entry.
+  # Each entry gets code "422XX" where XX is a 0-based index.
+  def handle_record_invalid(exception)
+    errors = exception.record.errors.map.with_index do |error, index|
+      {
+        message: error.full_message,
+        code:    format("422%02d", index)
+      }
+    end
+
+    render_errors(errors, status: :unprocessable_entity)
+  end
+
+  # Catch-all for any unmapped StandardError.
+  # Logs the exception and returns a generic 500 response.
+  def handle_standard_error(exception)
+    Rails.logger.error("[ErrorHandling] Unmapped exception: #{exception.class} — #{exception.message}")
+    Rails.logger.error(exception.backtrace&.first(10)&.join("\n"))
+
+    attrs = ErrorMessageBuilder.build(path: "domain.errors.generic.internal_server_error")
+    render_errors([ attrs ], status: :internal_server_error)
+  end
+
+  # Renders @errors via the shared jbuilder template.
+  def render_errors(errors_array, status:)
+    @errors = errors_array
+    render "errors/error", formats: [ :json ], status:
+  end
+
+  # Extracts the HTTP status integer from the first 3 chars of a code string.
+  # Falls back to 500 for unexpected formats.
+  def http_status_from_code(code)
+    Rack::Utils.status_code(code.to_s[0..2].to_i) rescue :internal_server_error
+  end
+end

--- a/backend/app/errors/authorization/base_authorization_error.rb
+++ b/backend/app/errors/authorization/base_authorization_error.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Authorization
+  # Abstract parent for all authentication / authorization exceptions.
+  #
+  # Subclasses should call +super+ with the translated message and code
+  # obtained from ErrorMessageBuilder:
+  #
+  #   class MyAuthError < Authorization::BaseAuthorizationError
+  #     PATH = "domain.errors.authentication.my_error"
+  #
+  #     def initialize(details = {})
+  #       attrs = ErrorMessageBuilder.build(path: PATH, details:)
+  #       super(**attrs)
+  #     end
+  #   end
+  class BaseAuthorizationError < BaseError; end
+end
+

--- a/backend/app/errors/base_error.rb
+++ b/backend/app/errors/base_error.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class BaseError < StandardError
+    attr_reader :code
+
+    # @param message [String] already-translated human-readable description
+    # @param code    [String] error code whose first 3 chars are the HTTP status
+    def initialize(message:, code:)
+      super(message)
+      @code = code.to_s
+    end
+  end
+

--- a/backend/app/errors/domain/base_domain_error.rb
+++ b/backend/app/errors/domain/base_domain_error.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Domain
+  # Abstract parent for all business-logic / domain exceptions.
+  #
+  # Subclasses should call +super+ with the translated message and code
+  # obtained from ErrorMessageBuilder:
+  #
+  #   class MyDomainError < Domain::BaseDomainError
+  #     PATH = "domain.errors.some_context.my_error"
+  #
+  #     def initialize(details = {})
+  #       attrs = ErrorMessageBuilder.build(path: PATH, details:)
+  #       super(**attrs)
+  #     end
+  #   end
+  class BaseDomainError < BaseError; end
+end
+

--- a/backend/app/errors/error_message_builder.rb
+++ b/backend/app/errors/error_message_builder.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Resolves error translations from the I18n locale files.
+#
+# Usage:
+#   ErrorMessageBuilder.build(
+#     path: "domain.errors.authentication.invalid_credentials"
+#   )
+#   # => { message: "Correo o contraseña incorrectos", code: "40101" }
+#
+# The +path+ must point to a locale node that contains both a +message+ and a
+# +code+ key.  Interpolation placeholders inside +message+ are resolved via
+# the optional +details+ hash.
+class ErrorMessageBuilder
+    # @param path    [String] dot-separated I18n key (relative to locale root)
+    # @param details [Hash]   interpolation variables (e.g. { model: "Usuario" })
+    # @return [Hash] { message: String, code: String }
+    def self.build(path:, details: {})
+      translation = I18n.t(path, raise: true)
+
+      message = I18n.t("#{path}.message", **details, raise: true)
+      code    = translation.fetch(:code) { raise KeyError, "Missing 'code' at #{path}" }
+
+      { message: message, code: code.to_s }
+    end
+  end
+

--- a/backend/app/services/authentication/errors.rb
+++ b/backend/app/services/authentication/errors.rb
@@ -2,23 +2,42 @@
 
 module Authentication
   module Errors
-    class Base < StandardError; end
+    # Convenience alias so existing references still resolve.
+    Base = Authorization::BaseAuthorizationError
+
+    class InvalidCredentials < Base
+      PATH = "domain.errors.authentication.invalid_credentials"
+
+      def initialize(details = {})
+        attrs = ErrorMessageBuilder.build(path: PATH, details:)
+        super(**attrs)
+      end
+    end
 
     class InvalidToken < Base
-      def initialize(msg = "Invalid authentication token")
-        super
+      PATH = "domain.errors.authentication.invalid_token"
+
+      def initialize(details = {})
+        attrs = ErrorMessageBuilder.build(path: PATH, details:)
+        super(**attrs)
       end
     end
 
     class TokenExpired < Base
-      def initialize(msg = "Authentication token has expired")
-        super
+      PATH = "domain.errors.authentication.token_expired"
+
+      def initialize(details = {})
+        attrs = ErrorMessageBuilder.build(path: PATH, details:)
+        super(**attrs)
       end
     end
 
     class UserNotFound < Base
-      def initialize(msg = "Authenticated user not found")
-        super
+      PATH = "domain.errors.authentication.user_not_found"
+
+      def initialize(details = {})
+        attrs = ErrorMessageBuilder.build(path: PATH, details:)
+        super(**attrs)
       end
     end
   end

--- a/backend/app/views/errors/error.json.jbuilder
+++ b/backend/app/views/errors/error.json.jbuilder
@@ -1,0 +1,5 @@
+json.errors @errors.each_with_index.to_a do |error, index|
+  json.message error[:message]
+  json.code    error[:code]
+  json.index   index
+end

--- a/backend/config/application.rb
+++ b/backend/config/application.rb
@@ -11,6 +11,9 @@ module Theflockchallenge
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 8.1
 
+    config.i18n.default_locale = :es
+    config.i18n.fallbacks = [:es]
+
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.

--- a/backend/config/locales/defaults/es.yml
+++ b/backend/config/locales/defaults/es.yml
@@ -6,6 +6,13 @@ es:
         restrict_dependent_destroy:
           has_one: No se puede eliminar el registro porque existe un %{record} dependiente
           has_many: No se puede eliminar el registro porque existen %{record} dependientes
+      models:
+        user:
+          attributes:
+            username:
+              invalid: solo letras, números y guiones bajos
+            handle:
+              invalid: solo letras, números y guiones bajos
   grammar:
     articles:
       one:
@@ -232,3 +239,23 @@ es:
       long: "%A, %d de %B de %Y a las %I:%M %p"
       short: "%d de %b a las %H:%M hrs"
     pm: pm
+  domain:
+    errors:
+      keys: {}
+      authentication:
+        invalid_credentials:
+          message: Correo o contraseña incorrectos
+          code: "40101"
+        invalid_token:
+          message: Token de autenticación inválido
+          code: "40102"
+        token_expired:
+          message: El token de autenticación ha expirado
+          code: "40103"
+        user_not_found:
+          message: Usuario autenticado no encontrado
+          code: "40104"
+      generic:
+        internal_server_error:
+          message: Error interno del servidor
+          code: "50001"

--- a/backend/config/locales/models/user/es.yml
+++ b/backend/config/locales/models/user/es.yml
@@ -1,0 +1,18 @@
+es:
+  activerecord:
+    models:
+      user: Usuario
+    attributes:
+      user:
+        email: Correo electrónico
+        username: Nombre de usuario
+        handle: Apodo
+        name: Nombre
+        password: Contraseña
+        password_confirmation: Confirmación de contraseña
+        bio: Biografía
+        location: Ubicación
+        website: Sitio web
+        date_of_birth: Fecha de nacimiento
+        avatar: Foto de perfil
+        banner: Imagen de portada

--- a/backend/lib/json_web_token.rb
+++ b/backend/lib/json_web_token.rb
@@ -19,7 +19,7 @@ class JsonWebToken
     rescue JWT::ExpiredSignature
       raise Authentication::Errors::TokenExpired
     rescue JWT::DecodeError => e
-      raise Authentication::Errors::InvalidToken, e.message
+      raise Authentication::Errors::InvalidToken
     end
 
     private

--- a/backend/test/errors/base_error_test.rb
+++ b/backend/test/errors/base_error_test.rb
@@ -1,0 +1,11 @@
+require "test_helper"
+
+class BaseErrorTest < ActiveSupport::TestCase
+  test "stores message and code, and inherits from StandardError" do
+    error = BaseError.new(message: "Custom error", code: "40001")
+    
+    assert_kind_of StandardError, error
+    assert_equal "Custom error", error.message
+    assert_equal "40001", error.code
+  end
+end

--- a/backend/test/errors/error_message_builder_test.rb
+++ b/backend/test/errors/error_message_builder_test.rb
@@ -1,0 +1,16 @@
+require "test_helper"
+
+class ErrorMessageBuilderTest < ActiveSupport::TestCase
+  test ".build returns correct I18n string given a valid path" do
+    result = ErrorMessageBuilder.build(path: "domain.errors.generic.internal_server_error")
+    
+    assert_equal "Error interno del servidor", result[:message]
+    assert_equal "50001", result[:code]
+  end
+
+  test ".build raises I18n::MissingTranslationData for a missing path" do
+    assert_raises(I18n::MissingTranslationData) do
+      ErrorMessageBuilder.build(path: "domain.errors.invalid_path.missing")
+    end
+  end
+end

--- a/backend/test/models/user_test.rb
+++ b/backend/test/models/user_test.rb
@@ -19,7 +19,7 @@ class UserTest < ActiveSupport::TestCase
   test "requires email" do
     user = User.new(valid_attributes.merge(email: ""))
     refute user.valid?
-    assert_includes user.errors[:email], "can't be blank"
+    assert_includes user.errors[:email], "no puede estar en blanco"
   end
 
   test "rejects malformed email" do


### PR DESCRIPTION
### Descripción

Se implementa un **manejador de errores centralizado** para la API de backend como un nuevo feature.  
Este cambio introduce una capa global de manejo de excepciones que permite capturar errores de forma consistente y devolver respuestas JSON estandarizadas, mejorando la mantenibilidad, la claridad del flujo de errores y la experiencia de consumo de la API durante el challenge técnico.

---

### Cambios

- Se agrega un concern de `ErrorHandling` al `ApplicationController` para centralizar el manejo de excepciones.
- Se eliminan bloques de manejo de errores dispersos en distintos controllers y se reemplazan por el uso de excepciones de dominio.
- Se introduce una jerarquía de errores bajo `app/errors/`, incluyendo:
  - `BaseError`
  - `BaseAuthorizationError`
  - Errores específicos de dominio
- Se implementa el rescate y normalización de:
  - Errores de aplicación (`BaseError`)
  - Errores de autorización
  - Errores de validación (`ActiveRecord::RecordInvalid`)
  - Errores inesperados (`StandardError`)
- Se estandariza la respuesta de errores JSON mediante el template `error.json.jbuilder`.
- Se agregan/actualizan tests para validar la correcta conversión y respuesta de errores.

### Checklist review

- [x] ¿Revisé el código escrito por la IA?
- [x] ¿Revisé problemas de arquitectura?
- [x] ¿Revisé los tests generados?
- [ ] ¿Corregí problemas en el código generado por la IA?
