### PR TITLE
feat(back): #7 me-IA add API documentation

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -56,3 +56,5 @@ group :development do
   # Auto-annotate models with schema comments (Ruby 3+ compatible fork of annotate)
   gem "annotaterb"
 end
+
+gem "scalar_ruby", "~> 1.1"

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -294,6 +294,7 @@ GEM
     ruby-vips (2.3.0)
       ffi (~> 1.12)
       logger
+    scalar_ruby (1.1.0)
     securerandom (0.4.1)
     solid_cable (3.0.12)
       actioncable (>= 7.2)
@@ -364,6 +365,7 @@ DEPENDENCIES
   rack-cors
   rails (~> 8.1.2)
   rubocop-rails-omakase
+  scalar_ruby (~> 1.1)
   solid_cable
   solid_cache
   solid_queue

--- a/backend/config/initializers/scalar.rb
+++ b/backend/config/initializers/scalar.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+Scalar.setup do |config|
+  config.page_title = "API Reference"
+
+  spec = {
+    openapi: "3.1.0",
+    info: { title: "API Documentation", version: "v1" },
+    paths: {},
+    components: { schemas: {}, responses: {} }
+  }
+
+  # Load partials
+  Dir.glob(Rails.root.join("docs", "api", "v1", "partials", "**", "*.yml")).sort.each do |file|
+    partial = YAML.load_file(file, permitted_classes: [Symbol]) || {}
+    spec[:components].deep_merge!(partial.deep_symbolize_keys)
+  end
+
+  # Load endpoints
+  Dir.glob(Rails.root.join("docs", "api", "v1", "*.yml")).sort.each do |file|
+    endpoint = YAML.load_file(file, permitted_classes: [Symbol]) || {}
+    spec[:paths].deep_merge!(endpoint.deep_symbolize_keys)
+  end
+
+  config.specification = spec.to_json
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  mount Scalar::UI, at: "/docs"
+
   get "up" => "rails/health#show", as: :rails_health_check
 
   namespace :auth do

--- a/backend/docs/api/v1/api_v1_profile.yml
+++ b/backend/docs/api/v1/api_v1_profile.yml
@@ -1,0 +1,61 @@
+---
+"/api/v1/profile":
+  :get:
+    :summary: Obtener el perfil del usuario actual
+    :tags:
+    - Profile
+    :security:
+    - :bearerAuth: []
+    :responses:
+      :200:
+        :description: Respuesta exitosa
+        :content:
+          :application/json:
+            :schema:
+              :$ref: "#/components/schemas/User"
+      :401:
+        :$ref: "#/components/responses/UnauthorizedError"
+  :patch:
+    :summary: Actualizar el perfil del usuario actual
+    :tags:
+    - Profile
+    :security:
+    - :bearerAuth: []
+    :requestBody:
+      :required: true
+      :content:
+        :application/json:
+          :schema:
+            :type: object
+            :properties:
+              :user:
+                :type: object
+                :properties:
+                  :name:
+                    :type: string
+                  :bio:
+                    :type: string
+                  :location:
+                    :type: string
+                  :website:
+                    :type: string
+                  :date_of_birth:
+                    :type: string
+                    :format: date
+                  :avatar:
+                    :type: string
+                    :format: binary
+                  :banner:
+                    :type: string
+                    :format: binary
+    :responses:
+      :200:
+        :description: Respuesta exitosa
+        :content:
+          :application/json:
+            :schema:
+              :$ref: "#/components/schemas/User"
+      :401:
+        :$ref: "#/components/responses/UnauthorizedError"
+      :422:
+        :$ref: "#/components/responses/UnprocessableEntityError"

--- a/backend/docs/api/v1/api_v1_profile_avatar.yml
+++ b/backend/docs/api/v1/api_v1_profile_avatar.yml
@@ -1,0 +1,21 @@
+---
+"/api/v1/profile/avatar":
+  :delete:
+    :summary: Eliminar el avatar del usuario
+    :tags:
+    - Profile
+    :security:
+    - :bearerAuth: []
+    :responses:
+      :200:
+        :description: Avatar eliminado exitosamente
+        :content:
+          :application/json:
+            :schema:
+              :type: object
+              :properties:
+                :message:
+                  :type: string
+                  :example: Avatar eliminado
+      :401:
+        :$ref: "#/components/responses/UnauthorizedError"

--- a/backend/docs/api/v1/api_v1_profile_banner.yml
+++ b/backend/docs/api/v1/api_v1_profile_banner.yml
@@ -1,0 +1,21 @@
+---
+"/api/v1/profile/banner":
+  :delete:
+    :summary: Eliminar el banner del usuario
+    :tags:
+    - Profile
+    :security:
+    - :bearerAuth: []
+    :responses:
+      :200:
+        :description: Banner eliminado exitosamente
+        :content:
+          :application/json:
+            :schema:
+              :type: object
+              :properties:
+                :message:
+                  :type: string
+                  :example: Banner eliminado
+      :401:
+        :$ref: "#/components/responses/UnauthorizedError"

--- a/backend/docs/api/v1/auth_login.yml
+++ b/backend/docs/api/v1/auth_login.yml
@@ -1,0 +1,37 @@
+---
+"/auth/login":
+  :post:
+    :summary: Iniciar sesión
+    :tags:
+    - Auth
+    :requestBody:
+      :required: true
+      :content:
+        :application/json:
+          :schema:
+            :type: object
+            :properties:
+              :session:
+                :type: object
+                :required:
+                - email
+                - password
+                :properties:
+                  :email:
+                    :type: string
+                    :format: email
+                  :password:
+                    :type: string
+                    :format: password
+    :responses:
+      :200:
+        :description: Inicio de sesión exitoso
+        :content:
+          :application/json:
+            :schema:
+              :$ref: "#/components/schemas/User"
+      :401:
+        :$ref: "#/components/responses/UnauthorizedError"
+      :404:
+        :$ref: "#/components/responses/NotFoundError"
+    :description: Autentica al usuario. Se utiliza JWT con cookies encriptadas.

--- a/backend/docs/api/v1/auth_logout.yml
+++ b/backend/docs/api/v1/auth_logout.yml
@@ -1,0 +1,19 @@
+---
+"/auth/logout":
+  :delete:
+    :summary: Cerrar sesión
+    :tags:
+    - Auth
+    :responses:
+      :200:
+        :description: Cierre de sesión exitoso
+        :content:
+          :application/json:
+            :schema:
+              :type: object
+              :properties:
+                :message:
+                  :type: string
+                  :example: Sesión cerrada exitosamente
+      :401:
+        :$ref: "#/components/responses/UnauthorizedError"

--- a/backend/docs/api/v1/auth_register.yml
+++ b/backend/docs/api/v1/auth_register.yml
@@ -1,0 +1,51 @@
+---
+"/auth/register":
+  :post:
+    :summary: Registrar un nuevo usuario
+    :tags:
+    - Auth
+    :description: Crea un nuevo usuario. Se utiliza JWT con cookies encriptadas.
+    :requestBody:
+      :required: true
+      :content:
+        :application/json:
+          :schema:
+            :type: object
+            :properties:
+              :user:
+                :type: object
+                :required:
+                - email
+                - username
+                - handle
+                - password
+                - password_confirmation
+                :properties:
+                  :email:
+                    :type: string
+                    :format: email
+                  :username:
+                    :type: string
+                  :handle:
+                    :type: string
+                  :name:
+                    :type: string
+                  :password:
+                    :type: string
+                    :format: password
+                  :password_confirmation:
+                    :type: string
+                    :format: password
+                  :date_of_birth:
+                    :type: string
+                    :format: date
+    :responses:
+      :201:
+        :description: Usuario creado exitosamente
+        :content:
+          :application/json:
+            :schema:
+              :$ref: "#/components/schemas/User"
+      :422:
+        :$ref: "#/components/responses/UnprocessableEntityError"
+    :description: Crea un nuevo usuario. Se utiliza JWT con cookies encriptadas.

--- a/backend/docs/api/v1/partials/errors.yml
+++ b/backend/docs/api/v1/partials/errors.yml
@@ -1,0 +1,68 @@
+---
+:schemas:
+  :ErrorItem:
+    :type: object
+    :properties:
+      :message:
+        :type: string
+        :example: El correo ya está en uso
+      :code:
+        :type: string
+        :example: '42200'
+      :index:
+        :type: integer
+        :example: 0
+    :required:
+    - message
+    - code
+    - index
+  :ErrorResponse:
+    :type: object
+    :properties:
+      :errors:
+        :type: array
+        :items:
+          :$ref: "#/components/schemas/ErrorItem"
+    :required:
+    - errors
+  :LegacyErrorResponse:
+    :type: object
+    :properties:
+      :errors:
+        :type: array
+        :items:
+          :type: string
+          :example: El nombre no puede estar en blanco
+    :required:
+    - errors
+:responses:
+  :UnauthorizedError:
+    :description: No autorizado
+    :content:
+      :application/json:
+        :schema:
+          :$ref: "#/components/schemas/ErrorResponse"
+        :example:
+          :errors:
+          - :message: Credenciales inválidas
+            :code: '40101'
+            :index: 0
+  :NotFoundError:
+    :description: No encontrado
+    :content:
+      :application/json:
+        :schema:
+          :$ref: "#/components/schemas/ErrorResponse"
+        :example:
+          :errors:
+          - :message: Recurso no encontrado
+            :code: '40400'
+            :index: 0
+  :UnprocessableEntityError:
+    :description: Entidad no procesable. Error de validación.
+    :content:
+      :application/json:
+        :schema:
+          :oneOf:
+          - :$ref: "#/components/schemas/ErrorResponse"
+          - :$ref: "#/components/schemas/LegacyErrorResponse"

--- a/backend/docs/api/v1/partials/user.yml
+++ b/backend/docs/api/v1/partials/user.yml
@@ -1,0 +1,62 @@
+---
+:schemas:
+  :User:
+    :type: object
+    :properties:
+      :id:
+        :type: integer
+        :example: 1
+      :email:
+        :type: string
+        :example: user@example.com
+      :username:
+        :type: string
+        :example: user123
+      :handle:
+        :type: string
+        :example: "@user123"
+      :name:
+        :type: string
+        :nullable: true
+        :example: John Doe
+      :bio:
+        :type: string
+        :nullable: true
+        :example: Hola Mundo
+      :location:
+        :type: string
+        :nullable: true
+        :example: Nueva York
+      :website:
+        :type: string
+        :nullable: true
+        :example: https://example.com
+      :date_of_birth:
+        :type: string
+        :format: date
+        :nullable: true
+        :example: '1990-01-01'
+      :verified:
+        :type: boolean
+        :example: false
+      :followers_count:
+        :type: integer
+        :example: 0
+      :following_count:
+        :type: integer
+        :example: 0
+      :tweets_count:
+        :type: integer
+        :example: 0
+      :avatar_url:
+        :type: string
+        :nullable: true
+        :example: http://localhost:3000/rails/active_storage/blobs/...
+      :banner_url:
+        :type: string
+        :nullable: true
+        :example:
+      :created_at:
+        :type: string
+        :format: date-time
+        :example: '2023-01-01T00:00:00Z'

--- a/backend/test/integration/docs_test.rb
+++ b/backend/test/integration/docs_test.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DocsTest < ActionDispatch::IntegrationTest
+  test "GET /docs returns success" do
+    get "/docs"
+    assert_response :success
+  end
+end


### PR DESCRIPTION
### Descripción

Se incorpora la **documentación oficial de la API** como un nuevo feature del proyecto, utilizando **OpenAPI** como estándar y **Scalar** como interfaz visual.  
La documentación se organiza de forma modular y escalable, alineada con la arquitectura existente, permitiendo a reviewers del challenge técnico inspeccionar fácilmente los endpoints, formatos de respuesta y errores soportados por la API.

Este cambio no altera el comportamiento de la aplicación ni introduce lógica funcional; únicamente agrega documentación estructurada y una UI dedicada para su consulta.

---

### Cambios

- Se agrega la configuración necesaria para integrar **Scalar** como UI de documentación de la API.
- Se crea la estructura de documentación bajo `docs/api/v1`, preparada para escalar por versión.
- Se definen archivos OpenAPI por endpoint, siguiendo la convención de nombrado basada en la ruta.
- Se incorporan parciales reutilizables para respuestas compartidas, incluyendo formatos de error.
- Se documentan los errores HTTP soportados por la API (ej. `401`, `404`, `422`).
- Cada endpoint documentado incluye un ejemplo de respuesta `200` alineado con los templates JBuilder existentes.
- La documentación sigue las convenciones recomendadas por Scalar para su correcta renderización.

---

### Checklist review

- [x] ¿Revisé el código escrito por la IA?
- [x] ¿Revisé problemas de arquitectura?
- [x] ¿Revisé los tests generados?
- [x] ¿Corregí problemas en el código generado por la IA?